### PR TITLE
fix build failure (ref. nlopes/slack#429)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3 // indirect
-	github.com/nlopes/slack v0.4.1-0.20181105183241-cd7590326897
+	github.com/nlopes/slack v0.4.1-0.20181123205743-38ac5e8c495b
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/whywaita/slack_lib v0.0.0-20181101084338-ab9413794b38
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3 h1:sHsPfNMAG70QAvKbddQ0uScZCHQoZsT5NykGRCeeeIs=
 github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=
-github.com/nlopes/slack v0.4.1-0.20181105183241-cd7590326897 h1:aGEIq4+lKi+3JGxd4fG3Xlv/dXwNHo1c006R+cBi2KU=
-github.com/nlopes/slack v0.4.1-0.20181105183241-cd7590326897/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
+github.com/nlopes/slack v0.4.1-0.20181123205743-38ac5e8c495b h1:lug6oqFxTyDeeoDLYeUIJcZGO8V3ddjXAC+PcUYziY8=
+github.com/nlopes/slack v0.4.1-0.20181123205743-38ac5e8c495b/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/whywaita/slack_lib v0.0.0-20181101084338-ab9413794b38 h1:kO4iTlAK6wzdPryIug3AoeW/eB5K3X1PvQ8+V8EpHdA=

--- a/utils/slack.go
+++ b/utils/slack.go
@@ -102,16 +102,26 @@ func PostMessageToChannel(toAPI, fromAPI *slack.Client, ev *slack.MessageEvent, 
 	param := slack.PostMessageParameters{
 		IconURL: icon,
 	}
-	attachment := slack.Attachment{
-		Pretext: msg,
-	}
-	param.Attachments = []slack.Attachment{attachment}
 	param.Username = user + "@" + strings.ToLower(fType[:1]) + ":" + position
 
-	_, _, err = toAPI.PostMessage(postChannelName, slack.MsgOptionText(msg, false), slack.MsgOptionPostMessageParameters(param))
-	if err != nil {
-		log.Println("[ERROR] postMessageToChannel is fail")
-		return "", err
+	attachments := ev.Attachments
+
+	if msg != "" {
+		_, _, err = toAPI.PostMessage(postChannelName, slack.MsgOptionText(msg, false), slack.MsgOptionPostMessageParameters(param))
+		if err != nil {
+			log.Println("[ERROR] postMessageToChannel is fail")
+			return "", err
+		}
+	}
+
+	if attachments != nil {
+		for _, attachment := range attachments {
+			_, _, err = toAPI.PostMessage(postChannelName, slack.MsgOptionPostMessageParameters(param), slack.MsgOptionAttachments(attachment))
+			if err != nil {
+				log.Println("[ERROR] postMessageToChannel is fail")
+				return "", err
+			}
+		}
 	}
 
 	return ev.Timestamp, nil


### PR DESCRIPTION
- `go build` fails
  - error: `"param.Attachments undefined (type slack.PostMessageParameters has no field or method Attachments)"`
- due to nlopes/slack#429
- This P-R fixes this repo and make it possible to post multi attachments at aggregation
  - and should fix multi-posting bug
